### PR TITLE
Unset PYTHONHOME

### DIFF
--- a/scripts/Start Stable Diffusion UI.cmd
+++ b/scripts/Start Stable Diffusion UI.cmd
@@ -4,6 +4,7 @@ cd /d %~dp0
 echo Install dir: %~dp0
 
 set PATH=C:\Windows\System32;%PATH%
+set PYTHONHOME=
 
 if exist "on_sd_start.bat" (
     echo ================================================================================

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -19,6 +19,7 @@ if [ -f "on_sd_start.bat" ]; then
     exit 1
 fi
 
+unset PYTHONHOME
 
 # set legacy installer's PATH, if it exists
 if [ -e "installer" ]; then export PATH="$(pwd)/installer/bin:$PATH"; fi


### PR DESCRIPTION
If the PYTHONHOME variable is set, python will not use the python libraries installed by ED, but those provided by the user. Unsetting PYTHONHOME ensures that the correct libraries are loaded.

https://discord.com/channels/1014774730907209781/1105238156804108398