### PR TITLE
Show COMSPEC variable in logs

### DIFF
--- a/scripts/Developer Console.cmd
+++ b/scripts/Developer Console.cmd
@@ -22,6 +22,8 @@ call where conda
 call conda --version
 
 echo.
+echo COMSPEC=%COMSPEC%
+echo.
 
 @rem activate the legacy environment (if present) and set PYTHONPATH
 if exist "installer_files\env" (

--- a/scripts/Start Stable Diffusion UI.cmd
+++ b/scripts/Start Stable Diffusion UI.cmd
@@ -36,8 +36,9 @@ call git --version
 
 call where conda
 call conda --version
+echo .
+echo COMSPEC=%COMSPEC%
 
 @rem Download the rest of the installer and UI
 call scripts\on_env_start.bat
-
 @pause


### PR DESCRIPTION
Non-standard COMSPEC settings can cause very odd behaviour on Windows, e.g. permission errors when trying to start `.cmd` files from the Explorer, or issues with nested commands, e.g. in `FOR` loops.

To simplify spotting these issues, I'd like to have the COMSPEC variable displayed in the log output.

The default value is `C:\Windows\System32\cmd.exe`