### PR TITLE
change event trigger to mousedown

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -400,7 +400,7 @@ function loadCustomModifiers() {
 }
 
 function showModifierContainer() {
-    document.addEventListener("click", checkIfClickedOutsideDropdownElem)
+    document.addEventListener("mousedown", checkIfClickedOutsideDropdownElem)
 
     modifierDropdown.dataset.active = true
     editorModifiersContainer.classList.add("active")
@@ -565,7 +565,7 @@ modifierSettingsCloseBtn.addEventListener("click", (e) => {
     modifierSettingsDialog.close()    
 })
 
-modifierSettingsDialog.addEventListener('click', function (event) {
+modifierSettingsDialog.addEventListener('mousedown', function (event) {
     var rect = modifierSettingsDialog.getBoundingClientRect();
     var isInDialog=(rect.top <= event.clientY && event.clientY <= rect.top + rect.height
       && rect.left <= event.clientX && event.clientX <= rect.left + rect.width);


### PR DESCRIPTION
This will fix an issue where the box is accidentally closed when attempting to quickly select text in the textarea.