### PR TITLE
Fix dialog closing when interacting with <select> child

### DIFF
--- a/ui/media/js/utils.js
+++ b/ui/media/js/utils.js
@@ -1074,6 +1074,12 @@ async function deleteKeys(keyToDelete) {
 
 function modalDialogCloseOnBackdropClick(dialog) {
     dialog.addEventListener('mousedown', function (event) {
+        // Firefox creates an event with clientX|Y = 0|0 when choosing an <option>.
+        // Test whether the element interacted with is a child of the dialog, but not the
+        // dialog itself (the backdrop would be a part of the dialog)
+        if (dialog.contains(event.target) && dialog != event.target) {
+            return
+        }
         var rect = dialog.getBoundingClientRect()
         var isInDialog=(rect.top <= event.clientY && event.clientY <= rect.top + rect.height
           && rect.left <= event.clientX && event.clientX <= rect.left + rect.width)


### PR DESCRIPTION
https://discord.com/channels/1014774730907209781/1021695193499582494/1127653577360425042 

'The.QCC: Embedding window. Switching between at end and at cursor closes the Embedding window'