### PR TITLE
enable DPM++ SDE, DPM++ 2s a and add DPM++ 2m SDE

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -162,7 +162,7 @@
                             <option value="dpm2_a">DPM2 Ancestral</option>
                             <option value="lms">LMS</option>
                             <option value="dpm_solver_stability">DPM Solver (Stability AI)</option>
-                            <option value="dpmpp_2s_a" class="k_diffusion-only">DPM++ 2s Ancestral (Karras)</option>
+                            <option value="dpmpp_2s_a">DPM++ 2s Ancestral (Karras)</option>
                             <option value="dpmpp_2m">DPM++ 2m (Karras)</option>
                             <option value="dpmpp_2m_sde" class="diffusers-only">DPM++ 2m SDE (Karras)</option>
                             <option value="dpmpp_sde">DPM++ SDE (Karras)</option>

--- a/ui/index.html
+++ b/ui/index.html
@@ -164,7 +164,8 @@
                             <option value="dpm_solver_stability">DPM Solver (Stability AI)</option>
                             <option value="dpmpp_2s_a" class="k_diffusion-only">DPM++ 2s Ancestral (Karras)</option>
                             <option value="dpmpp_2m">DPM++ 2m (Karras)</option>
-                            <option value="dpmpp_sde" class="k_diffusion-only">DPM++ SDE (Karras)</option>
+                            <option value="dpmpp_2m_sde" class="diffusers-only">DPM++ 2m SDE (Karras)</option>
+                            <option value="dpmpp_sde">DPM++ SDE (Karras)</option>
                             <option value="dpm_fast" class="k_diffusion-only">DPM Fast (Karras)</option>
                             <option value="dpm_adaptive" class="k_diffusion-only">DPM Adaptive (Karras)</option>
                             <option value="ddpm" class="diffusers-only">DDPM</option>


### PR DESCRIPTION
This PR enables DPM++ SDE and adds DPM++ 2m SDE.
requires [easydiffusion/sdkit#45](https://github.com/easydiffusion/sdkit/pull/45)