### PR TITLE
Add Bind IP option

### DIFF
--- a/scripts/on_sd_start.bat
+++ b/scripts/on_sd_start.bat
@@ -104,11 +104,14 @@ call python --version
 
 @FOR /F "tokens=* USEBACKQ" %%F IN (`python scripts\get_config.py --default=False net listen_to_network`) DO (
     if "%%F" EQU "True" (
-        @SET ED_BIND_IP=0.0.0.0    
+        @FOR /F "tokens=* USEBACKQ" %%G IN (`python scripts\get_config.py --default=0.0.0.0 net bind_ip`) DO (
+            @SET ED_BIND_IP=%%G
+        )
     ) else (
         @SET ED_BIND_IP=127.0.0.1
     )
 )
+
 
 @cd stable-diffusion
 

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -72,7 +72,7 @@ export SD_UI_PATH=`pwd`/ui
 export ED_BIND_PORT="$( python scripts/get_config.py --default=9000 net listen_port )"
 case "$( python scripts/get_config.py --default=False net listen_to_network )" in
     "True")
-        export ED_BIND_IP=$( python scripts/get_config.py --default=0.0.0.0) net bind_ip)
+        export ED_BIND_IP=$( python scripts/get_config.py --default=0.0.0.0 net bind_ip)
         ;;
     "False")
         export ED_BIND_IP=127.0.0.1

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -72,7 +72,7 @@ export SD_UI_PATH=`pwd`/ui
 export ED_BIND_PORT="$( python scripts/get_config.py --default=9000 net listen_port )"
 case "$( python scripts/get_config.py --default=False net listen_to_network )" in
     "True")
-        export ED_BIND_IP=0.0.0.0
+        export ED_BIND_IP=$( python scripts/get_config.py --default=0.0.0.0) net bind_ip)
         ;;
     "False")
         export ED_BIND_IP=127.0.0.1


### PR DESCRIPTION
Reimplementation of #1284

```yaml
net:
  listen_port: 9000
  listen_to_network: false
  bind_ip: 1.2.3.4
```
Defines an IP to bind to instead of 0.0.0.0
`listen_to_network` must be set to true for bind_ip to have an effect.