### PR TITLE
Update main.css to fix over scroll behavior on mobile devices

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -5,6 +5,7 @@
 
 html {
     position: relative;
+    overscroll-behavior-y: none;
 }
 
 body {
@@ -12,7 +13,6 @@ body {
     font-size: 11pt;
     background-color: var(--background-color1);
     color: var(--text-color);
-    overscroll-behavior-y: contain;
 }
 a {
     color: var(--link-color);


### PR DESCRIPTION
This change bypasses the browser's over scroll behavior since it's very easy to scroll and pinch an easydiffusion page and accidentally trigger the browser's "drag to refresh" function which will wipe out any work you may have been doing. The page should now "hard-stop" once you scroll to the top or bottom of the easydiffusion UI.  I switched from the "contain" variable to the "none" variable since contain seemed to have no effect, at least on iOS.

I have done a little play testing on various iOS browsers that work off webkit, and this change seems to function well.

I do not have any Android devices, so it has NOT been tested on android browsers.

Reference:
https://developer.chrome.com/blog/overscroll-behavior/
