### PR TITLE
Server side object store

### DIFF
--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -36,6 +36,7 @@ SD_UI_DIR = os.getenv("SD_UI_PATH", None)
 
 CONFIG_DIR = os.path.abspath(os.path.join(SD_UI_DIR, "..", "scripts"))
 MODELS_DIR = os.path.abspath(os.path.join(SD_DIR, "..", "models"))
+BUCKET_DIR = os.path.abspath(os.path.join(SD_DIR, "..", "bucket"))
 
 USER_PLUGINS_DIR = os.path.abspath(os.path.join(SD_DIR, "..", "plugins"))
 CORE_PLUGINS_DIR = os.path.abspath(os.path.join(SD_UI_DIR, "plugins"))

--- a/ui/easydiffusion/bucket_manager.py
+++ b/ui/easydiffusion/bucket_manager.py
@@ -1,0 +1,79 @@
+from easydiffusion import app
+from base64 import b32encode, b32decode
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+import os
+import mimetypes
+
+# Manage an object store bucket
+################################
+# All file and directory names will be base32 encoded. This way, no special 
+# character handling is required, and ../../.. can't be used to escape the
+# jail. 
+
+
+
+# get_object
+#
+def get_object(obj_path):
+    path, filename = _get_path(obj_path)
+
+    full_path = os.path.join(path, filename)
+
+    if os.path.isfile(full_path):
+        # If a file is requested, get its mime type and return the file
+        extension = os.path.splitext(obj_path)[1]
+        mime_type = mimetypes.guess_type(extension)[0]
+
+        return FileResponse(full_path, media_type=mime_type)
+
+    elif os.path.isdir(full_path):
+        # Return directory listing 
+        files = [ _b32_to_txt(x) for x in os.listdir(full_path) ]
+
+        return {"files": files}
+    else:
+        raise HTTPException(status_code=404, detail="No such object was found.")
+
+    return {"status": "OK"}
+
+def post_object(obj_path, file):
+    path, filename = _get_path(obj_path)
+
+    os.makedirs(path, exist_ok=True)
+
+    with open(os.path.join(path, filename),"wb") as f:
+        f.write(file)
+
+    return {"status": "OK", "path": path, "filename": filename }
+
+def delete_object(obj_path):
+    path, filename = _get_path(obj_path)
+    full_path = os.path.join(path, filename)
+
+    if os.path.isfile(full_path):
+        os.remove(full_path)
+        return {"status": "OK"}
+
+    return HTTPException(status_code=404, detail="No such object was found.")
+
+def _txt_to_b32(string):
+    return b32encode(string.encode()).decode().rstrip("=")
+
+def _b32_to_txt(string):
+    return b32decode(_pad_string_with_equals(string).encode(), casefold=True).decode()
+
+def _get_path(obj_path):
+    path_elements = obj_path.split("/")
+    dir_elements = [ _txt_to_b32(x) for x in path_elements[:-1] ]
+    path = os.path.join(app.BUCKET_DIR, *dir_elements)
+    filename = _txt_to_b32(path_elements[-1])
+
+    return (path, filename)
+
+def _pad_string_with_equals(string):
+    remainder = len(string) % 8
+    padding_length = (8 - remainder) % 8
+
+    return string + "=" * padding_length
+

--- a/ui/easydiffusion/server.py
+++ b/ui/easydiffusion/server.py
@@ -8,10 +8,10 @@ import os
 import traceback
 from typing import List, Union
 
-from easydiffusion import app, model_manager, task_manager
+from easydiffusion import app, model_manager, task_manager, bucket_manager
 from easydiffusion.types import GenerateImageRequest, MergeRequest, TaskData
 from easydiffusion.utils import log
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, UploadFile, File
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Extra
 from starlette.responses import FileResponse, JSONResponse, StreamingResponse
@@ -125,6 +125,18 @@ def init():
     @server_api.get("/")
     def read_root():
         return FileResponse(os.path.join(app.SD_UI_DIR, "index.html"), headers=NOCACHE_HEADERS)
+
+    @server_api.get("/bucket/{obj_path:path}")
+    def bucket_get_object(obj_path: str):
+        return bucket_manager.get_object(obj_path)
+
+    @server_api.post("/bucket/{obj_path:path}")
+    def bucket_post_object(obj_path: str, file: bytes = File()):
+        return bucket_manager.post_object(obj_path, file)
+
+    @server_api.delete("/bucket/{obj_path:path}")
+    def bucket_delete_object(obj_path: str):
+        return bucket_manager.delete_object(obj_path)
 
     @server_api.on_event("shutdown")
     def shutdown_event():  # Signal render thread to close on shutdown

--- a/ui/media/js/utils.js
+++ b/ui/media/js/utils.js
@@ -1156,4 +1156,45 @@ function makeDialogDraggable(element) {
     })() )
 }
 
+// saveObjectToBucket
+// - Save objects on the EasyDiffusion server
+// Plugin authors: Please prefix your pathes with "plugin/" plus your plugin name
+// If you store images on the server, you can then access them as 
+//   <img src="/bucket/plugin/my_plugin/image.png">
+//
+function saveObjectToBucket(obj, path) {
+    if (typeof(obj) == "object") {
+        obj = JSON.stringify(obj)
+    }
+    const formData = new FormData()
+    formData.append('file', obj)
+
+    fetch('/bucket/'+path, {
+      method: 'POST',
+      headers: { 'Accept': 'application/json' },
+      body: formData
+    })
+      .then(response => response.json())
+      .then(data => {
+        // Handle the response data
+        console.log(data)
+      })
+      .catch(error => {
+        // Handle any errors
+        throw new Error(error)
+      })
+}
+
+// loadObjectFromBucket
+// - retrieve a previously stored JSON object
+async function loadObjectFromBucket(path) {
+  try {
+    const response = await fetch("/bucket/"+path);
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw new Error('Failed to load JSON from URL');
+  }
+}
 


### PR DESCRIPTION
This PR provides a server side object store ("bucket") that can be used to store items in a (hopefully) secure manner on the server side.

On the Javascript side, two functions are provided: 
- `saveObjectToBucket` - Store any kind of object (JSON, text, image) on the server
- `loadObjectFromBucket` - Load a JSON object from the server.

Images stored to the bucket can be directly addressed: `<img src="/bucket/image.png">`

Images need to be stored in their binary form, not using the `data:` URL.

This PR is a prerequisite for
- Maintain a list of tokens for the different LORAs (to be displayed in the embeddings tab)
- Thumbnail management for embeddings