### PR TITLE
Fix SyntaxWarning on startup

### DIFF
--- a/ui/easydiffusion/utils/save_utils.py
+++ b/ui/easydiffusion/utils/save_utils.py
@@ -215,7 +215,7 @@ def get_printable_request(req: GenerateImageRequest, task_data: TaskData):
             metadata[key] = req_metadata[key]
         elif key in task_data_metadata:
             metadata[key] = task_data_metadata[key]
-        elif key is "use_embedding_models" and using_diffusers:
+        elif key == "use_embedding_models" and using_diffusers:
             embeddings_extensions = {".pt", ".bin", ".safetensors"}
             def scan_directory(directory_path: str):
                 used_embeddings = []


### PR DESCRIPTION
Fix

```sh
/ssd2/easydiffusion/ui/easydiffusion/utils/save_utils.py:225: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif key is "use_embedding_models" and using_diffusers:
```

logs on startup