### PR TITLE
Display Test Diffusers checkbox when enabling beta

### DIFF
--- a/ui/media/css/auto-save.css
+++ b/ui/media/css/auto-save.css
@@ -78,6 +78,7 @@
     border-bottom-right-radius: 12px;
 }
 
-.parameters-table .fa-fire {
+.parameters-table .fa-fire,
+.parameters-table .fa-bolt {
     color: #F7630C;
 }

--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -409,7 +409,8 @@ async function getAppConfig() {
             useBetaChannelField.checked = true
             document.querySelector("#updateBranchLabel").innerText = "(beta)"
         } else {
-            getParameterSettingsEntry("test_diffusers").style.display = "none"
+            console.log("None-Beta")
+            getParameterSettingsEntry("test_diffusers").classList.add("displayNone")
         }
         if (config.ui && config.ui.open_browser_on_start === false) {
             uiOpenBrowserOnStartField.checked = false
@@ -738,3 +739,11 @@ navigator.permissions.query({ name: "clipboard-write" }).then(function (result) 
 
 
 document.addEventListener("system_info_update", (e) => setDeviceInfo(e.detail))
+
+useBetaChannelField.addEventListener('change', (e) => {
+    if (e.target.checked) { 
+        getParameterSettingsEntry("test_diffusers").classList.remove('displayNone') 
+    } else { 
+        getParameterSettingsEntry("test_diffusers").classList.add('displayNone')
+    }
+})

--- a/ui/media/js/parameters.js
+++ b/ui/media/js/parameters.js
@@ -409,7 +409,6 @@ async function getAppConfig() {
             useBetaChannelField.checked = true
             document.querySelector("#updateBranchLabel").innerText = "(beta)"
         } else {
-            console.log("None-Beta")
             getParameterSettingsEntry("test_diffusers").classList.add("displayNone")
         }
         if (config.ui && config.ui.open_browser_on_start === false) {


### PR DESCRIPTION
Remove the need to reload the page after enabling beta. Make diffusers section directly available after enabling beta.