### PR TITLE
Support including Metadata in images shown on UI

### DIFF
--- a/ui/easydiffusion/tasks/render_images.py
+++ b/ui/easydiffusion/tasks/render_images.py
@@ -7,7 +7,7 @@ from easydiffusion import model_manager, runtime
 from easydiffusion.types import GenerateImageRequest, ModelsData, OutputFormatData
 from easydiffusion.types import Image as ResponseImage
 from easydiffusion.types import GenerateImageResponse, TaskData, UserInitiatedStop
-from easydiffusion.utils import get_printable_request, log, save_images_to_disk
+from easydiffusion.utils import get_printable_request, log, save_images_to_disk, get_metadata_entries_for_request
 from sdkit.generate import generate_images
 from sdkit.utils import (
     diffusers_latent_samples_to_images,
@@ -133,9 +133,13 @@ def make_images(
     images, seeds = make_images_internal(
         context, req, task_data, models_data, output_format, data_queue, task_temp_images, step_callback
     )
+    
+    metadata = [None for _ in images]
+    if "embed" in task_data.metadata_output_format:
+        metadata = get_metadata_entries_for_request(req, task_data, output_format)
 
     res = GenerateImageResponse(
-        req, task_data, models_data, output_format, images=construct_response(images, seeds, output_format)
+        req, task_data, models_data, output_format, images=construct_response(images, seeds, output_format, metadata)
     )
     res = res.json()
     data_queue.put(json.dumps(res))
@@ -266,7 +270,7 @@ def generate_images_internal(
     return images, user_stopped
 
 
-def construct_response(images: list, seeds: list, output_format: OutputFormatData):
+def construct_response(images: list, seeds: list, output_format: OutputFormatData, metadatas: list):
     return [
         ResponseImage(
             data=img_to_base64_str(
@@ -274,10 +278,11 @@ def construct_response(images: list, seeds: list, output_format: OutputFormatDat
                 output_format.output_format,
                 output_format.output_quality,
                 output_format.output_lossless,
+                metadata=metadata
             ),
             seed=seed,
         )
-        for img, seed in zip(images, seeds)
+        for img, seed, metadata in zip(images, seeds, metadatas)
     ]
 
 

--- a/ui/easydiffusion/utils/__init__.py
+++ b/ui/easydiffusion/utils/__init__.py
@@ -5,4 +5,5 @@ log = logging.getLogger("easydiffusion")
 from .save_utils import (
     save_images_to_disk,
     get_printable_request,
+    get_metadata_entries_for_request,
 )


### PR DESCRIPTION
This adds support for including metadata in images that are displayed on the ui. This means if the user individually downloads a single image, it will have the metadata attached. (Previously the only way to do this was to turn on the 'download all images generated' setting and grab them from that location)

Note that for this pull request I just hooked it up to the same setting because I'm not sure how ya'll would prefer to have it set up, but I figured this is a reasonable first implementation for it. 

Note that for this to work, it needs to have a change in sdkit, which is in this pull request:
https://github.com/easydiffusion/sdkit/pull/54

fixes #467 