### PR TITLE
Cancel/Stop/Remove task buttons

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -965,6 +965,8 @@ function abortTask(task) {
     task.progressBar.classList.remove("active")
     task["taskStatusLabel"].style.display = "none"
     task["stopTask"].innerHTML = '<i class="fa-solid fa-trash-can"></i> Remove'
+    task["stopTask"].style["background-color"] = "color-mix(in srgb, var(--status-orange) 50%, var(--background-color4))"
+    task["stopTask"].style["border"] = "0px"
     if (!task.instances?.some((r) => r.isPending)) {
         return
     }
@@ -1061,6 +1063,8 @@ function onTaskCompleted(task, reqBody, instance, outputContainer, stepUpdate) {
 
     task.isProcessing = false
     task["stopTask"].innerHTML = '<i class="fa-solid fa-trash-can"></i> Remove'
+    task["stopTask"].style["background-color"] = "color-mix(in srgb, var(--status-orange) 50%, var(--background-color4))"
+    task["stopTask"].style["border"] = "0px"
     task["taskStatusLabel"].style.display = "none"
 
     let time = millisecondsToStr(Date.now() - task.startTime)
@@ -1268,7 +1272,7 @@ function createTask(task) {
     taskEntry.innerHTML = ` <div class="header-content panel collapsible active">
                                 <i class="drag-handle fa-solid fa-grip"></i>
                                 <div class="taskStatusLabel">Enqueued</div>
-                                <button class="secondaryButton stopTask"><i class="fa-solid fa-trash-can"></i> Remove</button>
+                                <button class="secondaryButton stopTask"><i class="fa-solid fa-xmark"></i> Cancel</button>
                                 <button class="tertiaryButton useSettings"><i class="fa-solid fa-redo"></i> Use these settings</button>
                                 <div class="preview-prompt"></div>
                                 <div class="taskConfig">${taskConfig}</div>

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1061,8 +1061,6 @@ function onTaskCompleted(task, reqBody, instance, outputContainer, stepUpdate) {
 
     task.isProcessing = false
     task["stopTask"].innerHTML = '<i class="fa-solid fa-trash-can"></i> Remove'
-    task["stopTask"].style["background-color"] = "color-mix(in srgb, var(--status-orange) 50%, var(--background-color4))"
-    task["stopTask"].style["border"] = "0px"
     task["taskStatusLabel"].style.display = "none"
 
     let time = millisecondsToStr(Date.now() - task.startTime)

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -965,8 +965,6 @@ function abortTask(task) {
     task.progressBar.classList.remove("active")
     task["taskStatusLabel"].style.display = "none"
     task["stopTask"].innerHTML = '<i class="fa-solid fa-trash-can"></i> Remove'
-    task["stopTask"].style["background-color"] = "color-mix(in srgb, var(--status-orange) 50%, var(--background-color4))"
-    task["stopTask"].style["border"] = "0px"
     if (!task.instances?.some((r) => r.isPending)) {
         return
     }


### PR DESCRIPTION
So far, the button to remove a not yet rendered and a completed task was labeled 'Remove'. This can lead to confusions. This PR changes the label to 'Cancel' for not yet rendered tasks. It also changes the color of the undoable 'Remove' button
![image](https://github.com/easydiffusion/easydiffusion/assets/5852422/b9417fdd-2acd-4fae-b7d4-bebb655ed9ef)
