### PR TITLE
Warn when no controlnet model is chosen

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -1461,6 +1461,9 @@ button#save-system-settings-btn {
     cursor: pointer;;
 }
 
+.validation-failed {
+    border: solid 2px red;
+}
 /* SCROLLBARS */
 :root {
     --scrollbar-width: 14px;

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -834,7 +834,7 @@ function makeImage() {
     numInferenceStepsField.classList.remove("validation-failed")
 
     if (controlnetModelField.value === "" && IMAGE_REGEX.test(controlImagePreview.src)) {
-        alert("To use controlnets, choose a controlnet model")
+        alert("Please choose a ControlNet model, to use the ControlNet image.")
         document.getElementById("controlnet_model").classList.add("validation-failed")
         return
     }

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -821,12 +821,25 @@ function makeImage() {
     }
     if (!randomSeedField.checked && seedField.value == "") {
         alert('The "Seed" field must not be empty.')
+        seedField.classList.add("validation-failed")
         return
     }
+    seedField.classList.remove("validation-failed")
+
     if (numInferenceStepsField.value == "") {
         alert('The "Inference Steps" field must not be empty.')
+        numInferenceStepsField.classList.add("validation-failed")
         return
     }
+    numInferenceStepsField.classList.remove("validation-failed")
+
+    if (controlnetModelField.value === "" && IMAGE_REGEX.test(controlImagePreview.src)) {
+        alert("To use controlnets, choose a controlnet model")
+        document.getElementById("controlnet_model").classList.add("validation-failed")
+        return
+    }
+    document.getElementById("controlnet_model").classList.remove("validation-failed")
+
     if (numOutputsTotalField.value == "" || numOutputsTotalField.value == 0) {
         numOutputsTotalField.value = 1
     }


### PR DESCRIPTION
- Show a warning when a controlnet image has been chosen, but no model
- Highlight the seed, inference steps or controlnet model dropdown if their validation fails.
![image](https://github.com/easydiffusion/easydiffusion/assets/5852422/b51ba108-0d1f-46fa-b260-0bf1e8d56928)
