### PR TITLE
Remove safetensors hack

### DIFF
--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -58,11 +58,6 @@ def install(module_name: str, module_version: str):
 
     install_cmd = f"python -m pip install --upgrade {module_name}=={module_version}"
 
-    # hack for safetensors, until v3 gets released to the main branch
-    if module_name == "sdkit":
-        install_cmd += " safetensors==0.3.2"
-    # /hack
-
     if index_url:
         install_cmd += f" --index-url {index_url}"
     if module_name == "sdkit" and version("sdkit") is not None:


### PR DESCRIPTION
We should upgrade to 0.3.3, since it has wheels for all our supported plattforms.