### PR TITLE
feature: add a label to the task item html that indicates number of i…

### DIFF
--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -715,15 +715,26 @@ div.img-preview img {
 .header-content > .drag-handle {
     min-width: initial !important;
 }
-.taskStatusLabel, .taskNumberOfImagesLabel {
+.taskLabel {
     font-size: 8pt;
     background:var(--background-color2);
     border: 1px solid rgb(61, 62, 66);
     padding: 2pt 4pt;
     border-radius: 2pt;
-    margin-right: 5pt;
     display: inline;
 }
+.taskStatusLabel {
+    margin-right: 5pt;
+}
+.multiNumberOfImages {
+    font-weight: bold;
+}
+.taskNumberOfImagesLabel {
+    min-width: 30px;
+    display: inline-block;
+    text-align: center;
+}
+
 .activeTaskLabel {
     background:rgb(0, 90, 30);
     border: 1px solid rgb(0, 75, 19);

--- a/ui/media/css/main.css
+++ b/ui/media/css/main.css
@@ -711,7 +711,11 @@ div.img-preview img {
     margin-right: 6px;
     cursor: move;
 }
-.taskStatusLabel {
+/* Override conflicting css from imported library */
+.header-content > .drag-handle {
+    min-width: initial !important;
+}
+.taskStatusLabel, .taskNumberOfImagesLabel {
     font-size: 8pt;
     background:var(--background-color2);
     border: 1px solid rgb(61, 62, 66);

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1102,8 +1102,8 @@ function createTask(task) {
     taskEntry.className = "imageTaskContainer"
     taskEntry.innerHTML = ` <div class="header-content panel collapsible active">
                                 <i class="drag-handle fa-solid fa-grip"></i>
-                                ${task.numOutputsTotal > 1 ? `<div class="taskNumberOfImagesLabel">✕${task.numOutputsTotal}</div>` : ''}
-                                <div class="taskStatusLabel">Enqueued</div>
+                                <div class="taskLabel taskNumberOfImagesLabel ${task.numOutputsTotal > 1 ? 'multiNumberOfImages' : ''}">✕${task.numOutputsTotal}</div>
+                                <div class="taskLabel taskStatusLabel">Enqueued</div>
                                 <button class="secondaryButton stopTask"><i class="fa-solid fa-xmark"></i> Cancel</button>
                                 <button class="tertiaryButton useSettings"><i class="fa-solid fa-redo"></i> Use these settings</button>
                                 <div class="preview-prompt"></div>

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1102,6 +1102,7 @@ function createTask(task) {
     taskEntry.className = "imageTaskContainer"
     taskEntry.innerHTML = ` <div class="header-content panel collapsible active">
                                 <i class="drag-handle fa-solid fa-grip"></i>
+                                ${task.numOutputsTotal > 1 ? `<div class="taskNumberOfImagesLabel">✕${task.numOutputsTotal}</div>` : ''}
                                 <div class="taskStatusLabel">Enqueued</div>
                                 <button class="secondaryButton stopTask"><i class="fa-solid fa-xmark"></i> Cancel</button>
                                 <button class="tertiaryButton useSettings"><i class="fa-solid fa-redo"></i> Use these settings</button>


### PR DESCRIPTION
 Without this commit, it seems the UI simply does not surface this value until the task begins processing.  I will also say this is one of my favorite aspects of easydiffusion (its queuing system is very well done and integrated.)

![image](https://github.com/easydiffusion/easydiffusion/assets/7804797/5e10e215-4f4f-43ff-b25c-18c28b205e57)

Questions:
Dev decision made to not show when ✕1, but this offsets the prompt differently from ✕2 or more from ✕1.  Can always include this number (✕1) to 'fix' this minor UX issues, and maybe make it more washed out color wise (harder to see, more like a placeholder unless multi image.)  OTOH, it may be nice to know that a task _is_ going to produce batch images, but perhaps more important is prompt alignment (since many times, the prompt is the same in the beginning)

Note: Also included is a minor tweak.  Not sure if it's a plugin I installed or if others see it differently but also included is a css patch for overriding the `min-width: 50px` from `.drag-handle` conflicting css.  Could also rename the class to something different but for now this works fine.  Without this fix it looks like this:

![image](https://github.com/easydiffusion/easydiffusion/assets/7804797/486520d7-1f64-4e7e-8175-15f502625a3e)
