### PR TITLE
Error handling for models_dir

### DIFF
--- a/ui/easydiffusion/app.py
+++ b/ui/easydiffusion/app.py
@@ -104,7 +104,9 @@ def init():
     warnings.filterwarnings("ignore", category=UserWarning, message="TypedStorage is deprecated")
 
     config = getConfig()
-    MODELS_DIR = config.get("models_dir", MODELS_DIR)
+    config_models_dir = config.get("models_dir", None)
+    if (config_models_dir is not None and config_models_dir != ""):
+        MODELS_DIR = config_models_dir
 
 
 def init_render_threads():

--- a/ui/easydiffusion/model_manager.py
+++ b/ui/easydiffusion/model_manager.py
@@ -261,7 +261,24 @@ def make_model_folders():
     for model_type in KNOWN_MODEL_TYPES:
         model_dir_path = os.path.join(app.MODELS_DIR, model_type)
 
-        os.makedirs(model_dir_path, exist_ok=True)
+        try:
+            os.makedirs(model_dir_path, exist_ok=True)
+        except Exception as e:
+            from rich.console import Console
+            from rich.panel import Panel
+
+            Console().print(
+                Panel(
+                    "\n"
+                    + f"Error while creating the models directory: '{model_dir_path}'\n"
+                    + f"Error: {e}\n\n"
+                    + f"[white]Check the 'models_dir:' line in the file '{os.path.join(app.ROOT_DIR, 'config.yaml')}'.[/white]\n",
+                    title="Fatal Error starting Easy Diffusion",
+                    style="bold yellow on red",
+                )
+            )
+            input("Press Enter to terminate...")
+            exit(1)
 
         help_file_name = f"Place your {model_type} model files here.txt"
         help_file_contents = f'Supported extensions: {" or ".join(MODEL_EXTENSIONS.get(model_type))}'


### PR DESCRIPTION
- If the models_dir can not be created (permissions, drive doesn't exist), show an error message providing hints what went wrong:
![image](https://github.com/easydiffusion/easydiffusion/assets/5852422/1143c047-d8fd-4195-ae33-dbe8316d3aa2)

- If the `models_dir` entry in the yaml file is empty, use the default `easydiffusion/models` directory.
    https://discord.com/channels/1014774730907209781/1014774732018683926/1147249736072577104