### PR TITLE
Fill seed field with each generated value

### DIFF
--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -1036,6 +1036,7 @@ function makeImage() {
         hypernetworkStrengthField.value = hypernetworkStrengthSlider.value / 100
     }
     const taskTemplate = getCurrentUserRequest()
+    seedField.value = taskTemplate.reqBody.seed;
     const newTaskRequests = getPrompts().map((prompt) =>
         Object.assign({}, taskTemplate, {
             reqBody: Object.assign({ prompt: prompt }, taskTemplate.reqBody),


### PR DESCRIPTION
Hello,
would you mind setting the seed field to the current generated random number on each click on the MakeImage button?

That way, it would help people who want to continue with the last seed value, and plugins like e.g. [History](https://github.com/rbertus2000/sd-ui-plugins) that depend on that information.
The suggested change would additionally update the field as mentioned and it shouldn't interfere with the rest.
