### PR TITLE
Update lora-prompt-parser.plugin.js

### DIFF
--- a/ui/plugins/ui/lora-prompt-parser.plugin.js
+++ b/ui/plugins/ui/lora-prompt-parser.plugin.js
@@ -82,7 +82,9 @@
         }
 
         // Clean up the prompt string, e.g. from "apple, banana, <lora:...>, orange, <lora:...>  , pear <lora:...>, <lora:...>" to "apple, banana, orange, pear"
-        let cleanedPrompt = prompt.replace(regex, '').replace(/(\s*,\s*(?=\s*,|$))|(^\s*,\s*)|\s+/g, ' ').trim();
+        // let cleanedPrompt = prompt.replace(regex, '').replace(/(\s*,\s*(?=\s*,|$))|(^\s*,\s*)|\s+/g, ' ').trim();
+	// This line keeps /n in prompts. Good if you want to make prompt with multiple sub-prompts. Previous line would merge sub-prompts into one big prompt
+	let cleanedPrompt = prompt.replace(regex, '').trim();    
 		//console.log('Matches: ' + JSON.stringify(matches));
 
         // Return the array of matches and cleaned prompt string


### PR DESCRIPTION
Issue: 
When copy/pasting prompt with sub-prompts and lora, lora is extracted, but sub-prompts are merged into one big prompt.

Because I use script to copy/paste bunch of prompts with different lora's and let it run overnight, to test which lora is the best.

Solution:
To keep /n in prompts. I removed this part:
.replace(/(\s*,\s*(?=\s*,|$))|(^\s*,\s*)|\s+/g, ' ')