### PR TITLE
Allow access to the API from any network.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - **Major rewrite of the code** - We've switched to using diffusers under-the-hood, which allows us to release new features faster, and focus on making the UI and installer even easier to use.
 
 ### Detailed changelog
+* 3.0.7 - 3 May 2024 - Added the posibility to have CORS allowed on the api via configuration.
 * 3.0.7 - 11 Dec 2023 - Setting to enable/disable VAE tiling (in the Image Settings panel). Sometimes VAE tiling reduces the quality of the image, so this setting will help control that.
 * 3.0.6 - 18 Sep 2023 - Add thumbnails to embeddings from the UI, using the new `Upload Thumbnail` button in the Embeddings popup. Thanks @JeLuf.
 * 3.0.6 - 15 Sep 2023 - Fix broken embeddings dialog when LoRA information couldn't be fetched.

--- a/ui/easydiffusion/server.py
+++ b/ui/easydiffusion/server.py
@@ -23,6 +23,7 @@ from easydiffusion.types import (
 )
 from easydiffusion.utils import log
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Extra
 from starlette.responses import FileResponse, JSONResponse, StreamingResponse
@@ -32,6 +33,7 @@ log.info(f"started in {app.SD_DIR}")
 log.info(f"started at {datetime.datetime.now():%x %X}")
 
 server_api = FastAPI()
+
 
 NOCACHE_HEADERS = {
     "Cache-Control": "no-cache, no-store, must-revalidate",
@@ -86,6 +88,16 @@ def init():
         NoCacheStaticFiles(directory=os.path.join(app.SD_UI_DIR, "media")),
         name="media",
     )
+    config = app.getConfig()
+    
+    if config["net"]["api_allow_any_origins"]:
+        server_api.add_middleware(
+            CORSMiddleware,
+            allow_credentials=True,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"]
+        )
 
     for plugins_dir, dir_prefix in app.UI_PLUGINS_SOURCES:
         server_api.mount(


### PR DESCRIPTION
Because the app had an api, why not have cross site access so anyone can develop a UI for it? Even a native mobile app.

So this basically allows to have the application api public via the setting "api_allow_any_origins" in the "net" are from the config.yaml file.

