### PR TITLE
Update torch packages to ROCM 5.7 for Navi 3

### DIFF
--- a/scripts/check_modules.py
+++ b/scripts/check_modules.py
@@ -56,16 +56,16 @@ def install(module_name: str, module_version: str):
         amd_gpus = setup_amd_environment()
         if module_name == "torch":
             if "Navi 3" in amd_gpus:
-                # No AMD 7x00 support in rocm 5.2, needs nightly 5.5. build
-                module_version = "2.1.0.dev-20230614+rocm5.5"
-                index_url = "https://download.pytorch.org/whl/nightly/rocm5.5"
+                # No AMD 7x00 support in rocm 5.2, needs 5.7. build
+                module_version = "2.3.1+rocm5.7"
+                index_url = "https://download.pytorch.org/whl/rocm5.7"
             else:
                 module_version = "1.13.1+rocm5.2"
         elif module_name == "torchvision":
             if "Navi 3" in amd_gpus:
-                # No AMD 7x00 support in rocm 5.2, needs nightly 5.5. build
-                module_version = "0.16.0.dev-20230614+rocm5.5"
-                index_url = "https://download.pytorch.org/whl/nightly/rocm5.5"
+                # No AMD 7x00 support in rocm 5.2, needs 5.7. build
+                module_version = "0.18.1+rocm5.7"
+                index_url = "https://download.pytorch.org/whl/rocm5.7"
             else:
                 module_version = "0.14.1+rocm5.2"
     elif os_name == "Darwin":


### PR DESCRIPTION
People with RDNA3 (Navi 3) cards have trouble getting Easy Diffusion up and running (see https://discord.com/channels/1014774730907209781/1212916906835845160), and to get it to work it requires a newer ROCM version.
It was reported that while latest 6.0 has some issues with easy diffusion, 5.7 works fine, so this PR updates the ROCM version that gets installed to 5.7 for this generation of AMD cards. The package versions are the latest ones that are available for ROCM 5.7.
I've personally tested this on an RX 7900 XTX and it works (along with another change, PR incoming for that).