### PR TITLE
Remove inpaint size limit

### DIFF
--- a/ui/media/js/image-editor.js
+++ b/ui/media/js/image-editor.js
@@ -559,12 +559,12 @@ class ImageEditor {
         }
 
         if (width > height) {
-            var max_size = Math.min(parseInt(window.innerWidth * 0.9), width, 768)
+            var max_size = Math.min(parseInt(window.innerWidth * 0.9), width)
             var multiplier = max_size / width
             width = (multiplier * width).toFixed()
             height = (multiplier * height).toFixed()
         } else {
-            var max_size = Math.min(parseInt(window.innerHeight * 0.9), height, 768)
+            var max_size = Math.min(parseInt(window.innerHeight * 0.9), height)
             var multiplier = max_size / height
             width = (multiplier * width).toFixed()
             height = (multiplier * height).toFixed()

--- a/ui/media/js/image-editor.js
+++ b/ui/media/js/image-editor.js
@@ -557,14 +557,17 @@ class ImageEditor {
         if (width == this.width && height == this.height) {
             return
         }
-
+        //The below code tries to limit the size of the image to fit within the editor window.
+        //However, at this time, this causes problems with a mis-match between the mask size and
+        //the requested image size.  For now, allow the drawing/inpaint window to be as large
+        //as necessary.
         if (width > height) {
-            var max_size = Math.min(parseInt(window.innerWidth * 0.9), width)
+            var max_size = width; //Math.min(parseInt(window.innerWidth * 0.9), width)
             var multiplier = max_size / width
             width = (multiplier * width).toFixed()
             height = (multiplier * height).toFixed()
         } else {
-            var max_size = Math.min(parseInt(window.innerHeight * 0.9), height)
+            var max_size = height; //Math.min(parseInt(window.innerHeight * 0.9), height)
             var multiplier = max_size / height
             width = (multiplier * width).toFixed()
             height = (multiplier * height).toFixed()

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -626,8 +626,15 @@ function onUseAsInputClick(req, img) {
 
     //Force the image settings size to match the input, as inpaint currently only works correctly
     //if input image and generate sizes match.
+    var tempWidth = widthField.value;
+    var tempHeight = heightField.value;
     widthField.value = img.naturalWidth;
     heightField.value = img.naturalHeight;
+    //If it's unhappy with the new values, restore the original values.
+    if (widthField.value=="" || heightField.value=="") {
+        widthField.value = tempWidth;
+        heightField.value = tempHeight;
+    }
 }
 
 function onUseForControlnetClick(req, img) {

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -623,6 +623,11 @@ function onUseAsInputClick(req, img) {
     initImagePreview.src = imgData
 
     maskSetting.checked = false
+
+    //Force the image settings size to match the input, as inpaint currently only works correctly
+    //if input image and generate sizes match.
+    widthField.value = img.naturalWidth;
+    heightField.value = img.naturalHeight;
 }
 
 function onUseForControlnetClick(req, img) {

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -626,15 +626,10 @@ function onUseAsInputClick(req, img) {
 
     //Force the image settings size to match the input, as inpaint currently only works correctly
     //if input image and generate sizes match.
-    var tempWidth = widthField.value;
-    var tempHeight = heightField.value;
+    addImageSizeOption(img.naturalWidth);
+    addImageSizeOption(img.naturalHeight);
     widthField.value = img.naturalWidth;
     heightField.value = img.naturalHeight;
-    //If it's unhappy with the new values, restore the original values.
-    if (widthField.value=="" || heightField.value=="") {
-        widthField.value = tempWidth;
-        heightField.value = tempHeight;
-    }
 }
 
 function onUseForControlnetClick(req, img) {


### PR DESCRIPTION
With the limit removed, inpaint can work with image sizes larger than 768 pixels.