### PR TITLE
Update on_sd_start.sh

### DIFF
--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -62,5 +62,6 @@ else
     # Download the required packages only
     python scripts/check_modules.py
     # Download the models
-    python -c "from easydiffusion.model_manager import init; init()"
+    script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    PYTHONPATH="$script_dir/../ui" python -c "from easydiffusion.model_manager import init; init()"
 fi

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -52,6 +52,10 @@ cd ..
 # Skip the package download and prompt if INSTALL_ONLY=1 is set
 if [ "$INSTALL_ONLY" != "1" ]; then
     # Download the required packages
+
+    # see https://github.com/easydiffusion/easydiffusion/issues/1911
+    export TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1
+    
     python scripts/check_modules.py --launch-uvicorn
     read -p "Press any key to continue"
 else

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -65,7 +65,5 @@ else
     # Download the models
     script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     ui_absolute_path=$(readlink -f "$script_dir/../ui")
-    export SD_UI_DIR="$ui_absolute_path"
-    echo "SD_UI_DIR set to $SD_UI_DIR" 
-    PYTHONPATH="$ui_absolute_path" python -c "from easydiffusion.model_manager import init; init()"
+    PYTHONPATH="$ui_absolute_path" SD_UI_PATH="$ui_absolute_path" python -c "from easydiffusion.model_manager import init; init()"
 fi

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -48,8 +48,11 @@ if [ -e "ldm" ]; then mv ldm ldm-old; fi
 
 python -m pip install -q torchruntime
 
-cd ..
-# Download the required packages
-python scripts/check_modules.py --launch-uvicorn
+# Skip the package download and prompt if INSTALL_ONLY=1 is set
+if [ "$INSTALL_ONLY" != "1" ]; then
+    cd ..
+    # Download the required packages
+    python scripts/check_modules.py --launch-uvicorn
 
-read -p "Press any key to continue"
+    read -p "Press any key to continue"
+fi

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -66,5 +66,6 @@ else
     script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     ui_absolute_path=$(readlink -f "$script_dir/../ui")
     export SD_UI_DIR="$ui_absolute_path"
+    echo "SD_UI_DIR set to $SD_UI_DIR" 
     PYTHONPATH="$ui_absolute_path" python -c "from easydiffusion.model_manager import init; init()"
 fi

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -59,6 +59,7 @@ if [ "$INSTALL_ONLY" != "1" ]; then
     python scripts/check_modules.py --launch-uvicorn
     read -p "Press any key to continue"
 else
+    echo "Install only mode"
     # Download the required packages only
     python scripts/check_modules.py
     # Download the models

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -64,5 +64,6 @@ else
     # Download the models
     script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     ui_absolute_path=$(readlink -f "$script_dir/../ui")
-    PYTHONPATH="$ui_absolute_path" SD_UI_DIR="$ui_absolute_path" python -c "from easydiffusion.model_manager import init; init()"
+    export SD_UI_DIR="$ui_absolute_path"
+    PYTHONPATH="$ui_absolute_path" python -c "from easydiffusion.model_manager import init; init()"
 fi

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -48,11 +48,13 @@ if [ -e "ldm" ]; then mv ldm ldm-old; fi
 
 python -m pip install -q torchruntime
 
+cd ..
 # Skip the package download and prompt if INSTALL_ONLY=1 is set
 if [ "$INSTALL_ONLY" != "1" ]; then
-    cd ..
+    # Download the required packages
+    python scripts/check_modules.py
+else
     # Download the required packages
     python scripts/check_modules.py --launch-uvicorn
-
     read -p "Press any key to continue"
 fi

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -61,4 +61,6 @@ if [ "$INSTALL_ONLY" != "1" ]; then
 else
     # Download the required packages only
     python scripts/check_modules.py
+    # Download the models
+    python -c "from easydiffusion.model_manager import init; init()"
 fi

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -52,9 +52,9 @@ cd ..
 # Skip the package download and prompt if INSTALL_ONLY=1 is set
 if [ "$INSTALL_ONLY" != "1" ]; then
     # Download the required packages
-    python scripts/check_modules.py
-else
-    # Download the required packages
     python scripts/check_modules.py --launch-uvicorn
     read -p "Press any key to continue"
+else
+    # Download the required packages only
+    python scripts/check_modules.py
 fi

--- a/scripts/on_sd_start.sh
+++ b/scripts/on_sd_start.sh
@@ -63,5 +63,6 @@ else
     python scripts/check_modules.py
     # Download the models
     script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    PYTHONPATH="$script_dir/../ui" python -c "from easydiffusion.model_manager import init; init()"
+    ui_absolute_path=$(readlink -f "$script_dir/../ui")
+    PYTHONPATH="$ui_absolute_path" SD_UI_DIR="$ui_absolute_path" python -c "from easydiffusion.model_manager import init; init()"
 fi


### PR DESCRIPTION
Added flag to skip starting uvicorn and waiting for keypress if `INSTALL_ONLY` environment variable is set to `1`. This is to support non-interactive installation (e.g. for use in a Dockerfile)