### PR TITLE
Added Only masked area inpainting support

### DIFF
--- a/ui/easydiffusion/backends/common.py
+++ b/ui/easydiffusion/backends/common.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 import threading
 import psutil
@@ -7,7 +8,12 @@ def read_output(pipe, prefix=""):
     while True:
         output = pipe.readline()
         if output:
-            print(f"{prefix}{output.decode('utf-8')}", end="")
+            text = f"{prefix}{output.decode('utf-8', 'replace')}"
+            try:
+                print(text, end="", flush=True)
+            except (UnicodeEncodeError, ValueError):
+                enc = getattr(sys.stdout, "encoding", None) or "utf-8"
+                sys.stdout.write(text.encode(enc, "replace").decode(enc, "replace"))
         else:
             break  # Pipe is closed, subprocess has likely exited
 

--- a/ui/easydiffusion/tasks/render_images.py
+++ b/ui/easydiffusion/tasks/render_images.py
@@ -163,6 +163,70 @@ def print_task_info(
     log.info(f"save data: {save_data}")
 
 
+ONLY_MASKED_PADDING = 32  # px on the original image scale, like A1111's inpaint_full_res_padding
+
+
+def crop_init_to_mask(req, task_data):
+    "Crop init image + mask to the mask bbox ('Only masked area' inpaint). Mutates req. Returns info for paste-back, or None to use the whole picture."
+    if not getattr(task_data, "inpaint_only_masked", False):
+        return None
+    if req.init_image is None or not req.init_image_mask:
+        return None
+    try:
+        init_pil = get_image(req.init_image)
+        mask_raw = get_image(req.init_image_mask)
+        if init_pil is None or mask_raw is None:
+            return None
+        init_pil = init_pil.convert("RGB")
+        mask_rgba = mask_raw.convert("RGBA")
+        if mask_rgba.size != init_pil.size:
+            mask_rgba = resize_img(mask_rgba, init_pil.width, init_pil.height)
+        alpha = mask_rgba.getchannel("A")
+        if alpha.getextrema() == (255, 255):
+            # fully opaque (e.g. RGB white-on-black mask): white = masked area
+            alpha = mask_rgba.convert("L").point(lambda v: 255 if v >= 16 else 0)
+        bbox = alpha.getbbox()
+        if bbox is None:
+            return None
+        x0, y0, x1, y1 = bbox
+        x0 = max(0, x0 - ONLY_MASKED_PADDING)
+        y0 = max(0, y0 - ONLY_MASKED_PADDING)
+        x1 = min(init_pil.width, x1 + ONLY_MASKED_PADDING)
+        y1 = min(init_pil.height, y1 + ONLY_MASKED_PADDING)
+        if x1 - x0 < 8 or y1 - y0 < 8:
+            return None
+        crop_init = resize_img(init_pil.crop((x0, y0, x1, y1)), req.width, req.height)
+        crop_mask = resize_img(mask_rgba.crop((x0, y0, x1, y1)), req.width, req.height)
+        req.init_image = img_to_base64_str(crop_init)
+        req.init_image_mask = crop_mask
+        log.info(
+            f"Only-masked inpaint: cropped {init_pil.width}x{init_pil.height} to bbox "
+            f"{x0},{y0},{x1},{y1}, processing at {req.width}x{req.height}"
+        )
+        return {"bbox": (x0, y0, x1, y1), "orig": init_pil}
+    except Exception as e:
+        log.error(f"Only-masked crop failed, falling back to whole picture: {e}")
+        return None
+
+
+def paste_back_to_original(images, info):
+    "Paste generated crops back into the original image. images: list of base64 strings."
+    x0, y0, x1, y1 = info["bbox"]
+    orig = info["orig"]
+    out = []
+    for img_str in images:
+        try:
+            gen = base64_str_to_img(img_str).convert("RGB")
+            gen = resize_img(gen, x1 - x0, y1 - y0)
+            full = orig.copy()
+            full.paste(gen, (x0, y0))
+            out.append(img_to_base64_str(full))
+        except Exception as e:
+            log.error(f"Only-masked paste-back failed for one image: {e}")
+            out.append(img_str)
+    return out
+
+
 def make_images_internal(
     context,
     req: GenerateImageRequest,
@@ -181,6 +245,7 @@ def make_images_internal(
     if task_data.block_nsfw:
         filter_nsfw([Image.new("RGB", (1, 1))])  # hack - ensures that the model is available
 
+    only_masked_info = crop_init_to_mask(req, task_data)
     images = generate_images_internal(
         context,
         req,
@@ -193,6 +258,8 @@ def make_images_internal(
         task_data.stream_image_progress,
         task_data.stream_image_progress_interval,
     )
+    if only_masked_info is not None:
+        images = paste_back_to_original(images, only_masked_info)
     user_stopped = isinstance(task.error, StopAsyncIteration)
 
     filters, filter_params = task_data.filters, task_data.filter_params

--- a/ui/easydiffusion/types.py
+++ b/ui/easydiffusion/types.py
@@ -98,6 +98,7 @@ class RenderTaskData(TaskData):
     clip_skip: bool = False
     codeformer_upscale_faces: bool = False
     codeformer_fidelity: float = 0.5
+    inpaint_only_masked: bool = False  # process only the masked bbox at req size, paste back
 
 
 class MergeRequest(BaseModel):

--- a/ui/index.html
+++ b/ui/index.html
@@ -132,6 +132,7 @@
 
                     <div id="apply_color_correction_setting" class="pl-5"><input id="apply_color_correction" name="apply_color_correction" type="checkbox"> <label for="apply_color_correction">Preserve color profile <small>(helps during inpainting)</small></label></div>
                     <div id="strict_mask_border_setting" class="pl-5"><input id="strict_mask_border" name="strict_mask_border" type="checkbox"> <label for="strict_mask_border">Strict Mask Border <small>(won't modify outside the mask, but the mask border might be visible)</small></label></div>
+                    <div id="inpaint_only_masked_setting" class="pl-5"><input id="inpaint_only_masked" name="inpaint_only_masked" type="checkbox"> <label for="inpaint_only_masked">Only masked area <small>(process just the masked region at the requested size, keep the rest pixel-identical)</small></label></div>
 
                 </div>
 

--- a/ui/media/js/image-editor.js
+++ b/ui/media/js/image-editor.js
@@ -582,10 +582,29 @@ class ImageEditor {
         this.container.style.width = containerWidth + "px"
         this.container.style.height = containerHeight + "px"
 
+        // preserve the painted mask when only the canvas size changes (same image),
+        // e.g. the user edits Width/Height after painting. A new image still clears it.
+        let savedDrawing = null
+        if (this._keepDrawing && this.inpainter && this.layers.drawing) {
+            const dc = this.layers.drawing.canvas
+            if (dc.width > 0 && dc.height > 0) {
+                savedDrawing = document.createElement("canvas")
+                savedDrawing.width = dc.width
+                savedDrawing.height = dc.height
+                savedDrawing.getContext("2d").drawImage(dc, 0, 0)
+            }
+        }
+        this._keepDrawing = false
+
         Object.values(this.layers).forEach((layer) => {
             layer.canvas.width = width
             layer.canvas.height = height
         })
+
+        if (savedDrawing) {
+            this.layers.drawing.ctx.clearRect(0, 0, width, height)
+            this.layers.drawing.ctx.drawImage(savedDrawing, 0, 0, width, height)
+        }
 
         if (this.inpainter) {
             this.saveImage() // We've reset the size of the image so inpainting is different
@@ -601,10 +620,15 @@ class ImageEditor {
         this.drawing = false
         this.container.style.cursor = this.tool.cursor
     }
-    setImage(url, width, height) {
+    setImage(url, width, height, preserveDrawing = false) {
+        // Keep the painted mask only when the caller is resizing the current image.
+        // Comparing image URLs is unreliable because browsers can normalize them
+        // differently between the image element and the editor.
+        const keepDrawing = !!(url && this.inpainter && preserveDrawing)
+        this._keepDrawing = keepDrawing
         this.setSize(width, height)
         this.layers.background.ctx.clearRect(0, 0, this.width, this.height)
-        if (!(url && this.inpainter)) {
+        if (!keepDrawing) {
             this.layers.drawing.ctx.clearRect(0, 0, this.width, this.height)
         }
         if (url) {

--- a/ui/media/js/main.js
+++ b/ui/media/js/main.js
@@ -59,6 +59,7 @@ const taskConfigSetup = {
         lora_alpha: { label: "Lora Strength", visible: ({ reqBody }) => !!reqBody?.use_lora_model },
         preserve_init_image_color_profile: "Preserve Color Profile",
         strict_mask_border: "Strict Mask Border",
+        inpaint_only_masked: "Only Masked Area",
         use_controlnet_model: "ControlNet Model",
         control_alpha: {
             label: "ControlNet Strength",
@@ -118,8 +119,10 @@ let controlAlphaSlider = document.querySelector("#controlnet_alpha_slider")
 let controlAlphaField = document.querySelector("#controlnet_alpha")
 let applyColorCorrectionField = document.querySelector("#apply_color_correction")
 let strictMaskBorderField = document.querySelector("#strict_mask_border")
+let inpaintOnlyMaskedField = document.querySelector("#inpaint_only_masked")
 let colorCorrectionSetting = document.querySelector("#apply_color_correction_setting")
 let strictMaskBorderSetting = document.querySelector("#strict_mask_border_setting")
+let inpaintOnlyMaskedSetting = document.querySelector("#inpaint_only_masked_setting")
 let refImageContainer = document.querySelector("#editor-inputs-ref-images")
 let refImageSelector = document.querySelector("#ref_image_input")
 let refImagesList = document.querySelector("#ref_images_list")
@@ -1380,6 +1383,7 @@ function getCurrentUserRequest() {
         if (maskSetting.checked) {
             newTask.reqBody.mask = imageInpainter.getImg()
             newTask.reqBody.strict_mask_border = strictMaskBorderField.checked
+            newTask.reqBody.inpaint_only_masked = inpaintOnlyMaskedField.checked
         }
         newTask.reqBody.preserve_init_image_color_profile = applyColorCorrectionField.checked
         if (!testDiffusers.checked) {
@@ -1880,7 +1884,7 @@ function onDimensionChange() {
     if (!initImagePreviewContainer.classList.contains("has-image")) {
         imageEditor.setImage(null, widthValue, heightValue)
     } else {
-        imageInpainter.setImage(initImagePreview.src, widthValue, heightValue)
+        imageInpainter.setImage(initImagePreview.src, widthValue, heightValue, true)
     }
     if (widthValue < 512 && heightValue < 512) {
         smallImageWarning.classList.remove("displayNone")
@@ -2437,6 +2441,7 @@ function img2imgLoad() {
     initImagePreviewContainer.classList.add("has-image")
     colorCorrectionSetting.style.display = ""
     strictMaskBorderSetting.style.display = maskSetting.checked ? "" : "none"
+    inpaintOnlyMaskedSetting.style.display = maskSetting.checked ? "" : "none"
 
     initImageSizeBox.textContent = initImagePreview.naturalWidth + " x " + initImagePreview.naturalHeight
     imageEditor.setImage(this.src, initImagePreview.naturalWidth, initImagePreview.naturalHeight)
@@ -2455,6 +2460,7 @@ function img2imgUnload() {
     initImagePreviewContainer.classList.remove("has-image")
     colorCorrectionSetting.style.display = "none"
     strictMaskBorderSetting.style.display = "none"
+    inpaintOnlyMaskedSetting.style.display = "none"
     imageEditor.setImage(null, parseInt(widthField.value), parseInt(heightField.value))
 }
 initImagePreview.addEventListener("load", img2imgLoad)
@@ -2465,6 +2471,7 @@ maskSetting.addEventListener("click", function () {
 })
 maskSetting.addEventListener("change", function () {
     strictMaskBorderSetting.style.display = this.checked ? "" : "none"
+    inpaintOnlyMaskedSetting.style.display = this.checked ? "" : "none"
 })
 
 promptsFromFileBtn.addEventListener("click", function () {


### PR DESCRIPTION
## Summary

- Added the Only masked area option for inpainting.
- Cropped the inpainting input to the masked area with padding.
- Pasted the generated result back into the original image.
- Preserved the inpaint mask when changing image dimensions.
- Added the option to the task request and UI settings.
- Improved handling of non-UTF-8 backend output.

## Testing

- Python syntax checks passed.
- JavaScript syntax checks passed.
- Mask crop and paste behavior was verified.
- Local UI flow was verified: an image was loaded, a mask was painted, dimensions were changed, and Inpaint remained enabled.
- Local server startup was verified.

![Only masked area option](https://github.com/user-attachments/assets/26c87e5b-7f3a-43f4-9010-f3f0574cd6ef)